### PR TITLE
Implement Channel and IRC validation features with tests

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -218,7 +218,7 @@ BreakConstructorInitializersBeforeComma: true
 # ColumnLimit (unsigned)
 # The column limit.
 # A column limit of 0 means that there is no column limit. In this case, clang-format will respect the input’s line breaking decisions within statements unless they contradict other rules.
-ColumnLimit: 120
+ColumnLimit: 100
 
 # CommentPragmas (std::string)
 # A regular expression that describes comments with special meaning, which should not be split into lines or otherwise changed.

--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -28,6 +28,7 @@ public:
     bool hasMode(ChannelMode mode) const;
     bool hasMode(const char mode) const;
     void setMode(Client &client, bool enable, ChannelMode mode, std::string param = "");
+    void setMode(Client &client, bool enable, const char mode, std::string param = "");
     bool isEmpty() const;
 
 private:

--- a/include/ChannelManager.hpp
+++ b/include/ChannelManager.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <string>
+#include <memory>
+#include <unordered_map>
+
+class Channel;
+class Client;
+
+class ChannelManager
+{
+public:
+    ChannelManager();
+    ~ChannelManager();
+
+    bool channelExists(const std::string &name) const;
+    void createChannel(const std::string &name, Client &creator);
+    void removeChannel(const std::string &name);
+    Channel &getChannel(const std::string &name) const;
+
+private:
+    std::unordered_map<std::string, std::unique_ptr<Channel>> _channels;
+
+    // ascii casemapping, Defines the characters a to z
+    // to be considered the lower-case equivalents of the characters A to Z only.
+    std::string caseMapped(const std::string &name) const;
+};

--- a/include/IRCValidator.hpp
+++ b/include/IRCValidator.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+class IRCValidator
+{
+public:
+    static bool isValidNickname(int clientFd, const std::string &nickname);
+    static bool isValidUsername(int clientFd, const std::string &username);
+    static bool isValidChannelName(int clientFd, const std::string &channelName);
+    static bool isValidChannelMode(int clientFd, const std::string &mode);
+    static bool isValidServerPassword(int clientFd, const std::string &password);
+
+private:
+};

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -10,6 +10,7 @@ class SocketManager;
 class EventLoop;
 class ConnectionManager;
 class ClientIndex;
+class ChannelManager;
 
 class Server
 {
@@ -27,9 +28,8 @@ public:
     SocketManager &getSocketManager();
     EventLoop &getEventLoop();
     ClientIndex &getClients();
+    ChannelManager &getChannels();
     ConnectionManager &getConnectionManager();
-
-    // ChannelManager* getChannelManager();
 
     void pause();
     void resume();
@@ -37,6 +37,7 @@ public:
 private:
     static Server *_instance;
     std::unique_ptr<ClientIndex> _clients;
+    std::unique_ptr<ChannelManager> _channels;
     std::unique_ptr<SocketManager> _socketManager;
     std::unique_ptr<EventLoop> _eventLoop;
     std::unique_ptr<ConnectionManager> _connectionManager;

--- a/src/channel/Channel.cpp
+++ b/src/channel/Channel.cpp
@@ -160,6 +160,12 @@ void Channel::setMode(Client &client, bool enable, ChannelMode mode, std::string
     broadcastMessage(modeMsg);
 }
 
+void Channel::setMode(Client &client, bool enable, const char mode, std::string param)
+{
+    ChannelMode channelMode = static_cast<ChannelMode>(mode);
+    setMode(client, enable, channelMode, param);
+}
+
 bool Channel::isEmpty() const
 {
     return _connectedClients.empty();

--- a/src/server/ChannelManager.cpp
+++ b/src/server/ChannelManager.cpp
@@ -1,0 +1,51 @@
+#include <ChannelManager.hpp>
+#include <responses.hpp>
+#include <Client.hpp>
+#include <Channel.hpp>
+
+ChannelManager::ChannelManager()
+{}
+
+ChannelManager::~ChannelManager()
+{
+    _channels.clear();
+    std::cout << "channels cleared" << std::endl;
+}
+
+bool ChannelManager::channelExists(const std::string &name) const
+{
+    return _channels.find(caseMapped(name)) != _channels.end();
+}
+
+void ChannelManager::createChannel(const std::string &name, Client &creator)
+{
+    auto inserted = _channels.emplace(caseMapped(name), std::make_unique<Channel>(name, creator));
+    bool successful = inserted.second;
+    if (!successful) {
+        std::cerr << "Channel creation failed" << std::endl;
+    }
+}
+
+void ChannelManager::removeChannel(const std::string &name)
+{
+    if (channelExists(caseMapped(name)))
+        _channels.erase(caseMapped(name));
+}
+
+std::string ChannelManager::caseMapped(const std::string &name) const
+{
+    std::string casemapped = name;
+    for (char &c : casemapped) {
+        c = tolower(c);
+    }
+    return casemapped;
+}
+
+Channel &ChannelManager::getChannel(const std::string &name) const
+{
+    auto it = _channels.find(caseMapped(name));
+    if (it == _channels.end()) {
+        throw std::out_of_range("Channel '" + name + "' not found");
+    }
+    return *it->second;
+}

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -3,6 +3,7 @@
 #include <SocketManager.hpp>
 #include <EventLoop.hpp>
 #include <ClientIndex.hpp>
+#include <ChannelManager.hpp>
 #include <ConnectionManager.hpp>
 #include <responses.hpp>
 
@@ -13,9 +14,11 @@ Server::Server()
     , _password("42")
     , _paused(false)
     , _clients(std::make_unique<ClientIndex>())
+    , _channels(std::make_unique<ChannelManager>())
     , _socketManager(std::make_unique<SocketManager>(SERVER_PORT))
     , _eventLoop(std::make_unique<EventLoop>())
-    , _connectionManager(std::make_unique<ConnectionManager>(*_socketManager, *_eventLoop, *_clients))
+    , _connectionManager(
+          std::make_unique<ConnectionManager>(*_socketManager, *_eventLoop, *_clients))
     , _createdTime(getCurrentTime())
 {
     // setup signalshandlers
@@ -80,6 +83,11 @@ const bool Server::getIsPaused() const
 ClientIndex &Server::getClients()
 {
     return *_clients;
+}
+
+ChannelManager &Server::getChannels()
+{
+    return *_channels;
 }
 
 SocketManager &Server::getSocketManager()

--- a/src/utils/IRCValidator.cpp
+++ b/src/utils/IRCValidator.cpp
@@ -1,0 +1,26 @@
+#include <IRCValidator.hpp>
+
+bool IRCValidator::isValidNickname(int clientFd, const std::string &nickname)
+{
+    return true;
+}
+
+bool IRCValidator::isValidChannelName(int clientFd, const std::string &channelName)
+{
+    return true;
+}
+
+bool IRCValidator::isValidUsername(int clientFd, const std::string &username)
+{
+    return true;
+}
+
+bool IRCValidator::isValidChannelMode(int clientFd, const std::string &mode)
+{
+    return true;
+}
+
+bool IRCValidator::isValidServerPassword(int clientFd, const std::string &password)
+{
+    return true;
+}

--- a/tests/ChannelManagerTests.cpp
+++ b/tests/ChannelManagerTests.cpp
@@ -1,0 +1,130 @@
+#include <gtest/gtest.h>
+#include <ChannelManager.hpp>
+#include <Client.hpp>
+#include <Channel.hpp>
+
+class ChannelManagerTest : public ::testing::Test
+{
+protected:
+    ChannelManager channelManager;
+    Client *creator;
+    Client *regularUser;
+
+    void SetUp() override
+    {
+        creator = new Client(10);
+        creator->setNickname("creator");
+        regularUser = new Client(11);
+        regularUser->setNickname("regular");
+    }
+
+    void TearDown() override
+    {
+        delete creator;
+        delete regularUser;
+    }
+};
+
+// Test basic channel creation and existence
+TEST_F(ChannelManagerTest, CreationAndExistence)
+{
+    // Initially no channel exists
+    EXPECT_FALSE(channelManager.channelExists("#test"));
+
+    // Create a channel
+    channelManager.createChannel("#test", *creator);
+
+    // Check if channel exists
+    EXPECT_TRUE(channelManager.channelExists("#test"));
+}
+
+// Test channel removal
+TEST_F(ChannelManagerTest, RemoveChannel)
+{
+    // Create and verify channel
+    channelManager.createChannel("#test", *creator);
+    EXPECT_TRUE(channelManager.channelExists("#test"));
+
+    // Remove and verify it's gone
+    channelManager.removeChannel("#test");
+    EXPECT_FALSE(channelManager.channelExists("#test"));
+}
+
+// Test case mapping for channel names
+TEST_F(ChannelManagerTest, CaseMappingTest)
+{
+    // Create with one case, check with another
+    channelManager.createChannel("#TestChannel", *creator);
+
+    // These should all find the same channel
+    EXPECT_TRUE(channelManager.channelExists("#TestChannel"));
+    EXPECT_TRUE(channelManager.channelExists("#testchannel"));
+    EXPECT_TRUE(channelManager.channelExists("#TESTCHANNEL"));
+    EXPECT_TRUE(channelManager.channelExists("#tEsTcHaNnEl"));
+
+    // Get the channel using different cases
+    Channel &channel1 = channelManager.getChannel("#TestChannel");
+    Channel &channel2 = channelManager.getChannel("#testchannel");
+
+    // They should be the same object
+    EXPECT_EQ(&channel1, &channel2);
+    EXPECT_EQ(channel1.getName(), channel2.getName());
+}
+
+// Test channel access using getChannel
+TEST_F(ChannelManagerTest, GetChannel)
+{
+    // Create a channel
+    channelManager.createChannel("#test", *creator);
+
+    // Get the channel
+    Channel &channel = channelManager.getChannel("#test");
+
+    // Check properties
+    EXPECT_EQ(channel.getName(), "#test");
+    EXPECT_TRUE(creator->isOnChannel(&channel)); // Creator should be in the channel
+}
+
+// Test exception when getting non-existent channel
+TEST_F(ChannelManagerTest, GetNonExistentChannel)
+{
+    // Try to get a channel that doesn't exist
+    EXPECT_THROW(channelManager.getChannel("#nonexistent"), std::out_of_range);
+}
+
+// Test multiple channel handling
+TEST_F(ChannelManagerTest, MultipleChannels)
+{
+    // Create multiple channels
+    channelManager.createChannel("#first", *creator);
+    channelManager.createChannel("#second", *regularUser);
+    channelManager.createChannel("#third", *creator);
+
+    // Check they all exist
+    EXPECT_TRUE(channelManager.channelExists("#first"));
+    EXPECT_TRUE(channelManager.channelExists("#second"));
+    EXPECT_TRUE(channelManager.channelExists("#third"));
+
+    // Remove one
+    channelManager.removeChannel("#second");
+    EXPECT_FALSE(channelManager.channelExists("#second"));
+    EXPECT_TRUE(channelManager.channelExists("#first"));
+    EXPECT_TRUE(channelManager.channelExists("#third"));
+}
+
+// Test attempt to create duplicate channel
+TEST_F(ChannelManagerTest, CreateDuplicateChannel)
+{
+    // Create a channel
+    channelManager.createChannel("#test", *creator);
+
+    // Attempt to create the same channel again (should fail gracefully)
+    channelManager.createChannel("#test", *regularUser);
+
+    // Attempt to create the same channel again Casemapped differently
+    channelManager.createChannel("#TEST", *regularUser);
+
+    // Original creator should still be the channel's creator
+    Channel &channel = channelManager.getChannel("#test");
+    EXPECT_TRUE(creator->isOnChannel(&channel));
+}


### PR DESCRIPTION
Introduce a new `ChannelManager` for managing channels, an `IRCValidator` for input validation, and overload the `setMode` method in the `Channel` class. Add unit tests for the `ChannelManager` functionality.