### PR TITLE
Implement event loop abstraction with epoll and poll support

### DIFF
--- a/include/EventLoop.hpp
+++ b/include/EventLoop.hpp
@@ -25,5 +25,4 @@ public:
 
 private:
     int _epollFd;
-    bool _running;
 };

--- a/include/EventLoop.hpp
+++ b/include/EventLoop.hpp
@@ -18,11 +18,12 @@ public:
     EventLoop();
     ~EventLoop();
 
-    void addToWatch(int fd, uint32_t events);
+    void addToWatch(int fd);
     void removeFromWatch(int fd);
     std::vector<Event> waitForEvents(int timeoutMs);
     void shutdown();
 
 private:
     int _epollFd;
+    uint32_t _eventsToTrack;
 };

--- a/include/EventLoop.hpp
+++ b/include/EventLoop.hpp
@@ -1,10 +1,8 @@
 #pragma once
 
+#include <stdint.h>
 #include <vector>
-#include <sys/epoll.h>
-#include <cstring>
-#include <iostream>
-#include <unistd.h>
+#include <memory>
 
 struct Event
 {
@@ -15,15 +13,13 @@ struct Event
 class EventLoop
 {
 public:
-    EventLoop();
-    ~EventLoop();
-
-    void addToWatch(int fd);
-    void removeFromWatch(int fd);
-    std::vector<Event> waitForEvents(int timeoutMs);
-    void shutdown();
+    virtual ~EventLoop() = default;
+    virtual void addToWatch(int fd) = 0;
+    virtual void removeFromWatch(int fd) = 0;
+    virtual std::vector<Event> waitForEvents(int timeoutMs) = 0;
+    virtual void shutdown() = 0;
 
 private:
-    int _epollFd;
-    uint32_t _eventsToTrack;
 };
+
+std::unique_ptr<EventLoop> createEventLoop();

--- a/include/EventLoopEpoll.hpp
+++ b/include/EventLoopEpoll.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <vector>
+#include <sys/epoll.h>
+#include <cstring>
+#include <iostream>
+#include <unistd.h>
+#include <errno.h>
+#include <EventLoop.hpp>
+
+class EventLoopEpoll : public EventLoop
+{
+public:
+    EventLoopEpoll();
+    ~EventLoopEpoll();
+
+    void addToWatch(int fd);
+    void removeFromWatch(int fd);
+    std::vector<Event> waitForEvents(int timeoutMs);
+    void shutdown();
+
+private:
+    int _epollFd;
+    uint32_t _eventsToTrack;
+};

--- a/include/EventLoopPoll.hpp
+++ b/include/EventLoopPoll.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <EventLoop.hpp>
+#include <poll.h>
+#include <vector>
+#include <cstring>
+#include <errno.h>
+#include <iostream>
+
+class EventLoopPoll : public EventLoop
+{
+public:
+    EventLoopPoll();
+    ~EventLoopPoll();
+    void addToWatch(int fd);
+    void removeFromWatch(int fd);
+    std::vector<Event> waitForEvents(int timeoutMs);
+    void shutdown();
+
+private:
+    std::vector<struct pollfd> _pollFds;
+    uint32_t _eventsToTrack;
+};

--- a/src/server/ConnectionManager.cpp
+++ b/src/server/ConnectionManager.cpp
@@ -2,7 +2,8 @@
 #include <common.hpp>
 #include <responses.hpp>
 
-ConnectionManager::ConnectionManager(SocketManager &socketManager, EventLoop &EventLoop, ClientIndex &clients)
+ConnectionManager::ConnectionManager(SocketManager &socketManager, EventLoop &EventLoop,
+                                     ClientIndex &clients)
     : _socketManager(socketManager)
     , _EventLoop(EventLoop)
     , _clients(clients)
@@ -24,7 +25,7 @@ int ConnectionManager::handleNewClient()
     Client &client = _clients.getByFd(clientFd);
     client.setIp(ip);
     // add new client to epoll list
-    _EventLoop.addToWatch(clientFd, EPOLLIN | EPOLLET);
+    _EventLoop.addToWatch(clientFd);
     std::cout << "New client" << std::endl;
     std::cout << "  Socket: " << clientFd << std::endl;
     std::cout << "  IP:     " << ip << std::endl;

--- a/src/server/EventLoop.cpp
+++ b/src/server/EventLoop.cpp
@@ -3,6 +3,7 @@
 
 EventLoop::EventLoop()
     : _epollFd(epoll_create1(0))
+    , _eventsToTrack(EPOLLIN | EPOLLET)
 {
     if (_epollFd < 0) {
         std::cerr << "epoll create error" << std::endl;
@@ -14,11 +15,11 @@ EventLoop::~EventLoop()
     shutdown();
 }
 
-void EventLoop::addToWatch(int fd, uint32_t events)
+void EventLoop::addToWatch(int fd)
 {
     epoll_event ev;
     ev.data.fd = fd;
-    ev.events = events;
+    ev.events = _eventsToTrack;
     if (epoll_ctl(_epollFd, EPOLL_CTL_ADD, fd, &ev) == -1) {
         std::cerr << "Failed to add fd to epoll: " << strerror(errno) << std::endl;
     }

--- a/src/server/EventLoop.cpp
+++ b/src/server/EventLoop.cpp
@@ -3,7 +3,6 @@
 
 EventLoop::EventLoop()
     : _epollFd(epoll_create1(0))
-    , _running(true)
 {
     if (_epollFd < 0) {
         std::cerr << "epoll create error" << std::endl;
@@ -54,7 +53,6 @@ std::vector<Event> EventLoop::waitForEvents(int timeoutMs)
 
 void EventLoop::shutdown()
 {
-    _running = false;
     if (_epollFd >= 0) {
         close(_epollFd);
         _epollFd = -1;

--- a/src/server/EventLoopEpoll.cpp
+++ b/src/server/EventLoopEpoll.cpp
@@ -1,7 +1,7 @@
-#include <EventLoop.hpp>
+#include <EventLoopEpoll.hpp>
 #include <common.hpp>
 
-EventLoop::EventLoop()
+EventLoopEpoll::EventLoopEpoll()
     : _epollFd(epoll_create1(0))
     , _eventsToTrack(EPOLLIN | EPOLLET)
 {
@@ -10,12 +10,12 @@ EventLoop::EventLoop()
     }
 }
 
-EventLoop::~EventLoop()
+EventLoopEpoll::~EventLoopEpoll()
 {
     shutdown();
 }
 
-void EventLoop::addToWatch(int fd)
+void EventLoopEpoll::addToWatch(int fd)
 {
     epoll_event ev;
     ev.data.fd = fd;
@@ -25,14 +25,14 @@ void EventLoop::addToWatch(int fd)
     }
 }
 
-void EventLoop::removeFromWatch(int fd)
+void EventLoopEpoll::removeFromWatch(int fd)
 {
     if (epoll_ctl(_epollFd, EPOLL_CTL_DEL, fd, NULL) == -1) {
         std::cerr << "Failed to remove fd from epoll: " << strerror(errno) << std::endl;
     }
 }
 
-std::vector<Event> EventLoop::waitForEvents(int timeoutMs)
+std::vector<Event> EventLoopEpoll::waitForEvents(int timeoutMs)
 {
     epoll_event epollEvents[EPOLL_MAX_EVENTS] = {0};
     std::vector<Event> results;
@@ -52,7 +52,7 @@ std::vector<Event> EventLoop::waitForEvents(int timeoutMs)
     return results;
 }
 
-void EventLoop::shutdown()
+void EventLoopEpoll::shutdown()
 {
     if (_epollFd >= 0) {
         close(_epollFd);

--- a/src/server/EventLoopPoll.cpp
+++ b/src/server/EventLoopPoll.cpp
@@ -1,0 +1,61 @@
+#include <EventLoopPoll.hpp>
+
+EventLoopPoll::EventLoopPoll()
+    : _eventsToTrack(POLLIN)
+{}
+
+EventLoopPoll::~EventLoopPoll()
+{
+    shutdown();
+}
+
+void EventLoopPoll::addToWatch(int fd)
+{
+    struct pollfd pfd;
+
+    pfd.fd = fd;
+    pfd.events = _eventsToTrack;
+    pfd.revents = 0;
+    _pollFds.push_back(pfd);
+}
+
+void EventLoopPoll::removeFromWatch(int fd)
+{
+    for (auto it = _pollFds.begin(); it != _pollFds.end(); ++it) {
+        if (it->fd == fd) {
+            _pollFds.erase(it);
+            break;
+        }
+    }
+}
+
+std::vector<Event> EventLoopPoll::waitForEvents(int timeoutMs)
+{
+    std::vector<Event> events;
+    if (_pollFds.empty())
+        return events;
+    int nfds = poll(_pollFds.data(), _pollFds.size(), timeoutMs);
+    if (nfds < 0) {
+        if (errno != EINTR) {
+            std::cerr << "epoll failed: " << strerror(errno) << std::endl;
+        }
+        return events;
+    }
+    if (nfds > 0) {
+        for (pollfd &pfd : _pollFds) {
+            if (pfd.revents != 0) {
+                Event event;
+                event.fd = pfd.fd;
+                event.events = pfd.revents;
+                events.push_back(event);
+                pfd.revents = 0;
+            }
+        }
+    }
+    return events;
+}
+
+void EventLoopPoll::shutdown()
+{
+    _pollFds.clear();
+}

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -37,7 +37,7 @@ Server::~Server()
 void Server::start()
 {
     _serverFD = getSocketManager().initialize();
-    getEventLoop().addToWatch(_serverFD, EPOLLIN | EPOLLET);
+    getEventLoop().addToWatch(_serverFD);
     _running = true;
     loop();
 }

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -16,7 +16,7 @@ Server::Server()
     , _clients(std::make_unique<ClientIndex>())
     , _channels(std::make_unique<ChannelManager>())
     , _socketManager(std::make_unique<SocketManager>(SERVER_PORT))
-    , _eventLoop(std::make_unique<EventLoop>())
+    , _eventLoop(createEventLoop())
     , _connectionManager(
           std::make_unique<ConnectionManager>(*_socketManager, *_eventLoop, *_clients))
     , _createdTime(getCurrentTime())

--- a/src/utils/EventLoopFactory.cpp
+++ b/src/utils/EventLoopFactory.cpp
@@ -1,0 +1,12 @@
+#include <EventLoop.hpp>
+#include <EventLoopEpoll.hpp>
+#include <EventLoopPoll.hpp>
+
+std::unique_ptr<EventLoop> createEventLoop()
+{
+#if defined(__linux__)
+    return std::make_unique<EventLoopEpoll>();
+#else
+    return std::make_unique<EventLoopPoll>();
+#endif
+}

--- a/tests/stress_test.cpp
+++ b/tests/stress_test.cpp
@@ -1,0 +1,246 @@
+#include <gtest/gtest.h>
+#include <ClientIndex.hpp>
+#include <Server.hpp>
+#include <thread>
+#include <vector>
+#include <mutex>
+#include <atomic>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <cstring>
+#include <chrono>
+#include <common.hpp>
+#include <sys/resource.h>
+
+class StressTest : public ::testing::Test
+{
+protected:
+    Server *server;
+    std::thread serverThread;
+    std::atomic<bool> serverRunning{false};
+
+    // For capturing stdout
+    std::stringstream capturedOutput;
+    std::streambuf *originalCoutBuffer;
+
+    void SetUp() override
+    {
+        // Redirect stdout to our stringstream
+        originalCoutBuffer = std::cout.rdbuf();
+        std::cout.rdbuf(capturedOutput.rdbuf());
+
+        server = new Server();
+        serverRunning = true;
+        serverThread = std::thread([this]() {
+            try {
+                this->server->start();
+            }
+            catch (const std::exception &e) {
+                std::cerr << "Server exception: " << e.what() << std::endl;
+            }
+        });
+
+        // Give the server time to initialize
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    }
+
+    void TearDown() override
+    {
+        if (serverRunning) {
+            server->shutdown();
+            serverRunning = false;
+        }
+        if (serverThread.joinable()) {
+            serverThread.join();
+        }
+        delete server;
+
+        // Restore stdout
+        std::cout.rdbuf(originalCoutBuffer);
+    }
+
+    // Check if a specific pattern appears in the server logs
+    bool serverLogContains(const std::string &pattern)
+    {
+        return capturedOutput.str().find(pattern) != std::string::npos;
+    }
+
+    // Count occurrences of a pattern in logs
+    int countInServerLog(const std::string &pattern)
+    {
+        std::string logs = capturedOutput.str();
+        int count = 0;
+        size_t pos = 0;
+        while ((pos = logs.find(pattern, pos)) != std::string::npos) {
+            ++count;
+            pos += pattern.length();
+        }
+        return count;
+    }
+
+    void printFdLimits()
+    {
+        struct rlimit rlim;
+        if (getrlimit(RLIMIT_NOFILE, &rlim) == 0) {
+            std::cout << "File descriptor limits: soft=" << rlim.rlim_cur
+                      << ", hard=" << rlim.rlim_max << std::endl;
+        }
+        else {
+            std::cerr << "Failed to get file descriptor limits: " << strerror(errno) << std::endl;
+        }
+    }
+
+    // Helper function to connect a client
+    int connectClient()
+    {
+        int sockfd = socket(AF_INET, SOCK_STREAM, 0);
+        if (sockfd < 0) {
+            return -1;
+        }
+
+        struct sockaddr_in serv_addr;
+        std::memset(&serv_addr, 0, sizeof(serv_addr));
+        serv_addr.sin_family = AF_INET;
+        serv_addr.sin_port = htons(SERVER_PORT);
+        inet_pton(AF_INET, "127.0.0.1", &serv_addr.sin_addr);
+
+        if (connect(sockfd, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0) {
+            close(sockfd);
+            return -1;
+        }
+
+        return sockfd;
+    }
+
+    // Helper function to send IRC commands
+    bool sendCommand(int sockfd, const std::string &cmd)
+    {
+        std::string command = cmd + "\r\n";
+        return send(sockfd, command.c_str(), command.length(), 0) > 0;
+    }
+
+    // Helper function to read response
+    std::string readResponse(int sockfd, int timeout_ms = 1000)
+    {
+        char buffer[512];
+        std::string response;
+
+        fd_set readfds;
+        struct timeval tv;
+        tv.tv_sec = timeout_ms / 1000;
+        tv.tv_usec = (timeout_ms % 1000) * 1000;
+
+        FD_ZERO(&readfds);
+        FD_SET(sockfd, &readfds);
+
+        if (select(sockfd + 1, &readfds, NULL, NULL, &tv) > 0) {
+            int bytes = recv(sockfd, buffer, sizeof(buffer) - 1, 0);
+            if (bytes > 0) {
+                buffer[bytes] = '\0';
+                response = buffer;
+            }
+        }
+
+        return response;
+    }
+};
+
+TEST_F(StressTest, MassClientConnections)
+{
+    const int NUM_CLIENTS = 25;
+    std::vector<std::thread> clientThreads;
+    std::vector<int> clientFds(NUM_CLIENTS, -1);
+    std::mutex mtx;
+    std::atomic<int> connected{0};
+    std::atomic<int> registered{0};
+
+    // Create client threads
+    for (int i = 0; i < NUM_CLIENTS; i++) {
+        clientThreads.emplace_back([i, &clientFds, &mtx, &connected, &registered, this]() {
+            // Sleep a bit to stagger connections
+            std::this_thread::sleep_for(std::chrono::milliseconds(i * 10));
+
+            // Connect client
+            int sockfd = this->connectClient();
+            if (sockfd < 0) {
+                std::cerr << "Client " << i << " failed to connect" << std::endl;
+                return;
+            }
+
+            {
+                std::lock_guard<std::mutex> lock(mtx);
+                clientFds[i] = sockfd;
+            }
+
+            connected++;
+
+            // Read welcome message
+            // std::string response = this->readResponse(sockfd);
+
+            // Register user
+            std::string nick = "user" + std::to_string(i);
+            this->sendCommand(sockfd, "PASS 42");
+            this->sendCommand(sockfd, "NICK " + nick);
+            this->sendCommand(sockfd, "USER " + nick + " 0 * :Test User " + std::to_string(i));
+
+            // Give server time to process registration
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            registered++;
+
+            // Wait for all clients to connect before proceeding
+            while (registered < NUM_CLIENTS) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            }
+
+            // Wait another second
+            // std::this_thread::sleep_for(std::chrono::seconds(1));
+
+            // Quit
+            this->sendCommand(sockfd, "QUIT :Leaving");
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+            close(sockfd);
+        });
+    }
+
+    // Wait for all client threads to finish
+    for (auto &t : clientThreads) {
+        if (t.joinable()) {
+            t.join();
+        }
+    }
+
+    // Give server time to process all disconnections
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    // Get the server log contents
+    std::string serverOutput = capturedOutput.str();
+    std::cerr << serverOutput;
+
+    // 1. Count NICK registrations
+    int nickCount = countInServerLog("NICK user");
+    EXPECT_GE(nickCount, NUM_CLIENTS);
+
+    // 2. Count USER registrations
+    int userCount = countInServerLog("USER user");
+    EXPECT_GE(userCount, NUM_CLIENTS);
+
+    // 3. Count QUIT messages
+    int quitCount = countInServerLog("QUIT");
+    EXPECT_GE(quitCount, NUM_CLIENTS);
+
+    // 4. Verify final client count is zero
+    EXPECT_EQ(server->getClients().size(), 0);
+
+    // 5. Check that all connections were successful
+    EXPECT_EQ(connected.load(), NUM_CLIENTS);
+    EXPECT_EQ(registered.load(), NUM_CLIENTS);
+
+    // Close any remaining open sockets
+    for (int fd : clientFds) {
+        if (fd != -1) {
+            close(fd);
+        }
+    }
+}


### PR DESCRIPTION
Refactor the event loop implementation to support both epoll and poll mechanisms. Simplify event watching by removing unnecessary parameters and unused members. Add stress tests for handling multiple client connections.